### PR TITLE
Bug fixes 30th June

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cornemaxhelper",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Corne MAX Helper",
   "main": ".webpack/main",
   "author": "Mechboards",

--- a/src/device.ts
+++ b/src/device.ts
@@ -149,6 +149,9 @@ export class Device extends EventEmitter {
     var buffer: any[] = [];
     if (process.platform == "win32") buffer.push(0xff);
     buffer.push(0x07, 0x00, command, half, ...data);
+    while (buffer.length < ((process.platform == "win32" ? 33:32))) {
+      buffer.push(0x00);
+    }
     return (await this.writeBuffer.push(buffer)) > data.length;
     // return (await this.device.write(buffer)) > data.length;
   };

--- a/src/device.ts
+++ b/src/device.ts
@@ -9,7 +9,6 @@ import { screens } from "./screens";
 import { uploadImage } from "./uploadImage";
 
 import { setTimeout } from "timers/promises";
-import { LIBUSB_TRANSFER_TYPE_ISOCHRONOUS } from "usb/dist/usb";
 
 log.errorHandler.startCatching();
 
@@ -134,6 +133,14 @@ export class Device extends EventEmitter {
     });
     this.config.updateField((half == HALF.MASTER ? 'masterScreen' : 'accessToken'), screen) 
   };
+
+  // clears all interval timers and resets screens to default
+  clear = async () => {
+    this.master.intervalIDs.forEach((id) => {clearInterval(id);});
+    this.slave.intervalIDs.forEach((id) => {clearInterval(id);});
+    this.write(CODES.SCREEN, HALF.MASTER, [0]);
+    this.write(CODES.SCREEN, HALF.SLAVE, [0]);
+  }
 
   /**
    * Write to HID Device, adding in the default config bytes

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import { screens } from "./screens";
 
 import log from "electron-log/main";
 
+import { setTimeout } from "timers/promises";
+
 import { updateElectronApp } from 'update-electron-app'
 updateElectronApp()
 
@@ -85,7 +87,14 @@ const contextMenu = (connected: boolean, f?: boolean): Menu =>
             },
              ] : []
           ),
-          { label: "Quit", click: app.quit },
+          { label: "Quit", click: async () => {
+               if (device.device != null){
+                 device.clear();
+                }
+              await setTimeout(50);
+              app.quit();
+            } 
+          },
         ]
 
   );
@@ -137,3 +146,4 @@ const disconnectSpotify = () => {
   spotifyDeAuth(config);
   tray.setContextMenu(contextMenu(device.device != null))
 };
+ 

--- a/src/modules/spotify.ts
+++ b/src/modules/spotify.ts
@@ -56,6 +56,13 @@ export const spotifyAuth = async (c: Config) => {
   const win = new BrowserWindow({ width: 800, height: 600, icon: "./images/icon" });
   win.loadURL(authUrl.toString());
   win.show();
+
+  // Prevent app from quitting when this window is closed
+  win.on("close", (event) => {
+    event.preventDefault();
+    win.hide();
+  });
+
   // Handle the callback by wathcing for the redirect uri
   win.webContents.on("will-navigate", (event, url) => {
     if (!url.startsWith(redirectUri)) return;

--- a/src/screens.ts
+++ b/src/screens.ts
@@ -15,7 +15,7 @@ export const screens: ScreenSync[] = [
     name: "Stats",
     code: 0x01,
     modules: [syncSystemStats],
-    frequency: 5000,
+    frequency: 2000,
   },
   {
     id: 2,


### PR DESCRIPTION
- Fixes a bug where the app quits when the Spotify window for now playing is dismissed
- Ensure the buffer is filled to 32 bytes (33 on win) before any write commands occur
- Improve shutdown behavior to reset the displayed screens when the app is quit
- Increase the frequency of stats updates inline with other functions